### PR TITLE
Perform bitwise operation to convert number to 32 bits in hashCode()

### DIFF
--- a/src/App/pages/search/md-parser.js
+++ b/src/App/pages/search/md-parser.js
@@ -32,7 +32,7 @@ const convertTokens = ({ tokens }, urlResolver) =>
 function hashCode(str) {
   let h = 0;
   for (let i = 0; i < str.length; i++) {
-    h = h * 31 + (str.charCodeAt(i) & 0xff);
+    h = (h * 31 + (str.charCodeAt(i) & 0xff)) | 0;
   }
   return h;
 }


### PR DESCRIPTION
... otherwise the number quickly becomes `Infinity` for long code snippets and the `key=` does not change