### PR TITLE
remove the scroll on vespa search tabs on smaller screens

### DIFF
--- a/src/App/pages/search/search-sources.js
+++ b/src/App/pages/search/search-sources.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { ScrollArea, Tabs } from '@mantine/core';
+import { Tabs } from '@mantine/core';
 import { useLocation } from 'react-router-dom';
 import { ALL_NAMESPACES, useSearchContext } from 'App/libs/provider';
 import { Icon } from 'App/components';
@@ -35,20 +35,18 @@ export function SearchSources() {
   const { namespaces } = parseUrlParams(location.search);
   const defaultValue = namespaces?.length === 1 ? namespaces[0] : 'all';
   return (
-    <ScrollArea h="40">
-      <Tabs defaultValue={defaultValue}>
-        <Tabs.List style={{ flexWrap: 'nowrap' }}>
-          {ALL_NAMESPACES.map(({ id, name, icon }) => (
-            <Source
-              key={id}
-              id={id}
-              name={name}
-              icon={icon}
-              selectedTab={defaultValue}
-            />
-          ))}
-        </Tabs.List>
-      </Tabs>
-    </ScrollArea>
+    <Tabs defaultValue={defaultValue}>
+      <Tabs.List style={{ flexWrap: 'wrap', gap: '0.3rem' }}>
+        {ALL_NAMESPACES.map(({ id, name, icon }) => (
+          <Source
+            key={id}
+            id={id}
+            name={name}
+            icon={icon}
+            selectedTab={defaultValue}
+          />
+        ))}
+      </Tabs.List>
+    </Tabs>
   );
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

On smaller screens the tabs need to scroll. This PR removes the scroll
